### PR TITLE
fix: download URL

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -37,7 +37,7 @@ installer() {
 
 download_url() {
   local version=$1
-  echo "https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/${version}/spring-boot-cli-${version}-bin.tar.gz"
+  echo "https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-cli/${version}/spring-boot-cli-${version}-bin.tar.gz"
 }
 
 fail() {


### PR DESCRIPTION
Official download URL changed for the cli tools, not it uses maven central repo, as seen here: https://docs.spring.io/spring-boot/docs/current/reference/html/getting-started.html#getting-started.installing.cli